### PR TITLE
Update green-tokens-ios to 0.0.4 and adjust input backgrounds

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "66bc3672c47765bbfc5817a4122263f7215ef1d71b1739d3c603863a887cb551",
+  "originHash" : "3da509c9433746a661218be3a80e7d7fa1a8e776553b73920b19849eb3ccafe9",
   "pins" : [
     {
       "identity" : "green-tokens-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/seb-oss/green-tokens-ios",
       "state" : {
-        "revision" : "96624185d1c25a066240f5bb0c382a9f0c0ebb1f",
-        "version" : "0.0.2"
+        "revision" : "44022f4d362af84e684fec70a2544ced152a8108",
+        "version" : "0.0.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/seb-oss/green-tokens-ios", exact: "0.0.2")
+        .package(url: "https://github.com/seb-oss/green-tokens-ios", exact: "0.0.4")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/SebGreenComponents/Input/FloatingLabelInput.swift
+++ b/Sources/SebGreenComponents/Input/FloatingLabelInput.swift
@@ -82,7 +82,7 @@ private extension FloatingLabelInput {
 
 private extension FloatingLabelInput {
     var background: some View {
-        Color.l2Elevated01
+        Color.l3Elevated02
             .cornerRadius(.spaceS)
     }
 }

--- a/Sources/SebGreenComponents/Input/LabelOutsideInput.swift
+++ b/Sources/SebGreenComponents/Input/LabelOutsideInput.swift
@@ -95,7 +95,7 @@ private extension LabelOutsideInput {
 
 private extension LabelOutsideInput {
     var background: some View {
-        Color.l2Elevated01
+        Color.l3Elevated02
             .cornerRadius(.spaceS)
     }
 }


### PR DESCRIPTION
Bump green-tokens-ios dependency to version 0.0.4. Update background color in FloatingLabelInput and LabelOutsideInput from l2Elevated01 to l3Elevated02 for consistency with new token definitions.