### PR TITLE
MCORE-156: Pin green-tokens-ios to v0.0.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f6484de46408c95f774a1563df39329650548eb660e754c5278d14a5b4127c6a",
+  "originHash" : "3487cb80d71d8e515fc5b29148dbb4245d0e7e47092d323939561a843690f8c8",
   "pins" : [
     {
       "identity" : "green-tokens-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/seb-oss/green-tokens-ios",
       "state" : {
-        "branch" : "feature/updated-gds-colors-from-figma-export",
-        "revision" : "54b7dc913cc063d3411237715226bf8a45fa83d1"
+        "revision" : "9f37a89ba487a054d1e86aa10599bcc7562d5663",
+        "version" : "0.0.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/seb-oss/green-tokens-ios",
-            branch: "feature/updated-gds-colors-from-figma-export"
+            exact: "0.0.6"
         ),
         .package(
             url: "https://github.com/pointfreeco/swift-snapshot-testing",


### PR DESCRIPTION
Update Package.swift to use an exact dependency version for green-tokens-ios (0.0.6) instead of tracking the feature branch. Package.resolved was updated to reflect the pinned revision and originHash, ensuring reproducible builds by using the released package version rather than a branch tip.