### PR TITLE
Demo container for wrapping component demo views

### DIFF
--- a/Sources/SebGreenComponents/DemoContainer.swift
+++ b/Sources/SebGreenComponents/DemoContainer.swift
@@ -1,0 +1,54 @@
+import GdsKit
+import SwiftUI
+
+struct DemoContainer<Configuration: View, Content: View>: View {
+    private let title: String
+    private let configuration: Configuration
+    private let content: Content
+    private let storageKey: String
+    
+    @Environment(\.level) private var level
+    
+    @AppStorage private var shouldShowConfigurationView: Bool
+    
+    init(
+        _ title: String,
+        @ViewBuilder configuration: () -> Configuration,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.configuration = configuration()
+        self.content = content()
+        
+        let storageKey = title.lowercased().filter { $0.isLetter || $0.isNumber }
+        self.storageKey = storageKey
+        self._shouldShowConfigurationView = AppStorage(
+            wrappedValue: true,
+            "shouldShowConfigurationView_\(storageKey)"
+        )
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: .spaceXl) {
+                if shouldShowConfigurationView {
+                    configuration
+                }
+                
+                content
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+        }
+        .animation(.easeIn, value: shouldShowConfigurationView)
+        .background(level.colors.neutral02)
+        .navigationTitle(title)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: { withAnimation { shouldShowConfigurationView.toggle() } }) {
+                    Image(systemName: "gear")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add demo container to simplify creating demo views of the components. Collapsible config view at the top. Content below.

<img width="231" height="462" alt="Screenshot 2026-03-03 at 10 24 20" src="https://github.com/user-attachments/assets/be71a4aa-89f9-4ed8-b7a3-51c130707ca9" />
