### PR TITLE
feat(surface): add presentationSurface modifier and greenSheet helpers

### DIFF
--- a/Sources/SebGreenComponents/Callout/Callout.swift
+++ b/Sources/SebGreenComponents/Callout/Callout.swift
@@ -6,20 +6,17 @@ public struct Callout: View {
 
     private let title: any StringProtocol
     private let shortText: any StringProtocol
-    private let message: (any StringProtocol)?
     private let action: Callout.Action?
     private let onClose: (() -> Void)?
 
     public init(
         _ title: any StringProtocol,
         shortText: any StringProtocol,
-        message: (any StringProtocol)? = nil,
         action: Callout.Action? = nil,
         onClose: (() -> Void)? = nil
     ) {
         self.title = title
         self.shortText = shortText
-        self.message = message
         self.action = action
         self.onClose = onClose
     }
@@ -78,6 +75,6 @@ public struct Callout: View {
 }
 
 @available(iOS 17, *)
-#Preview("Alert") {
+#Preview("Callout") {
     CalloutDemo()
 }

--- a/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
+++ b/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
@@ -69,12 +69,32 @@ extension View {
     }
 
     public func sheetTitle(
-        _ title: String,
+        _ key: LocalizedStringKey,
+        tableName: String? = nil,
+        bundle: Bundle? = nil,
+        comment: StaticString? = nil,
         typography: Typography = .headingXs
     ) -> some View {
         toolbar {
             ToolbarItem(placement: .principal) {
-                Text(title)
+                Text(
+                    key,
+                    tableName: tableName,
+                    bundle: bundle,
+                    comment: comment
+                )
+                .font(.seb(typography))
+            }
+        }
+    }
+
+    public func sheetTitle(
+        _ content: some StringProtocol,
+        typography: Typography = .headingXs
+    ) -> some View {
+        toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(content)
                     .font(.seb(typography))
             }
         }

--- a/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
+++ b/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
@@ -1,0 +1,135 @@
+import GdsKit
+import SwiftUI
+
+@available(iOS 16, *)
+private struct GreenSheetNavigationStack<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(content: content)
+                .navigationBarTitleDisplayMode(.inline)
+                .scrollBasedOnSizeIfAvailable()
+        }
+        .scrollIndicators(.hidden)
+    }
+}
+
+private struct SheetCloseButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        if #available(iOS 26, *) {
+            Button(role: .close, action: action)
+                .tint(Color.contentNeutral02)
+        } else {
+            Button(systemName: "xmark.circle.fill", action: action)
+                .foregroundStyle(Color.contentNeutral02, .surfaceAware)
+                .font(.system(size: 24))
+        }
+    }
+}
+
+@available(iOS 16, *)
+extension View {
+    public func greenSheet(
+        isPresented: Binding<Bool>,
+        surface: Surface = .neutral02,
+        @ViewBuilder content: @escaping () -> some View
+    ) -> some View {
+        sheet(isPresented: isPresented) {
+            if #available(iOS 16.4, *) {
+                GreenSheetNavigationStack(content: content)
+                    .presentationSurface(surface)
+            } else {
+                GreenSheetNavigationStack(content: content)
+                    .surface(surface, level: .level2)
+            }
+        }
+    }
+
+    public func greenSheet<Item: Identifiable, Content: View>(
+        item: Binding<Item?>,
+        surface: Surface = .neutral02,
+        @ViewBuilder content: @escaping (Item) -> Content
+    ) -> some View {
+        sheet(item: item) { itemValue in
+            if #available(iOS 16.4, *) {
+                GreenSheetNavigationStack {
+                    content(itemValue)
+                }
+                .presentationSurface(surface)
+            } else {
+                GreenSheetNavigationStack {
+                    content(itemValue)
+                }
+                .surface(surface, level: .level2)
+            }
+        }
+    }
+
+    public func sheetTitle(
+        _ title: String,
+        typography: Typography = .headingXs
+    ) -> some View {
+        toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(title)
+                    .font(.seb(typography))
+            }
+        }
+    }
+
+    public func sheetCloseButton(
+        placement: ToolbarItemPlacement = .topBarTrailing,
+        action: @escaping () -> Void
+    ) -> some View {
+        toolbar {
+            ToolbarItem(placement: placement) {
+                SheetCloseButton(action: action)
+            }
+        }
+    }
+
+    @ViewBuilder
+    fileprivate func scrollBasedOnSizeIfAvailable() -> some View {
+        if #available(iOS 16.4, *) {
+            self
+                .scrollBounceBehavior(.basedOnSize)
+        } else {
+            self
+        }
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    @Previewable @State var present = false
+
+    Button("Present simple sheet") {
+        present = true
+    }
+    .greenSheet(isPresented: $present, surface: .neutral01) {
+        Text(
+            """
+            What is Lorem Ipsum?
+
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+
+            Why do we use it?
+
+            It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).
+
+            Where does it come from?
+
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
+            """
+        )
+        .padding(.horizontal)
+        .sheetTitle("Amazing title", typography: .headingS)
+        .sheetCloseButton {
+            present = false
+        }
+        .presentationDetents([.medium, .large])
+    }
+}

--- a/Sources/SebGreenComponents/Surface/View+Surface.swift
+++ b/Sources/SebGreenComponents/Surface/View+Surface.swift
@@ -18,4 +18,23 @@ extension View {
             .environment(\.surface, surface)
             .level(level)
     }
+
+    /// Sets the sheet presentation background and propagates the surface to child views.
+    /// - Parameters:
+    ///   - surface: The surface to apply as the presentation background.
+    ///   - level: The elevation level for the surface color. Defaults to `.level2`.
+    @available(iOS 16.4, *)
+    public func presentationSurface(
+        _ surface: Surface,
+        level: Level = .level2
+    ) -> some View {
+        self
+            .presentationBackground(
+                .levelBased { @Sendable level, _ in
+                    surface.color(for: level)
+                }
+            )
+            .environment(\.surface, surface)
+            .level(level)
+    }
 }


### PR DESCRIPTION
## What

- **`View+Surface.swift`**: adds `presentationSurface(_:level:)` (iOS 16.4+) — like `surface()` but uses `.presentationBackground()` instead of `.background()`, so it correctly paints the sheet chrome. Defaults to `.level2` since sheets sit above the base surface.
- **`View+GreenSheet.swift`**: introduces `greenSheet(isPresented:)` and `greenSheet(item:)` view extensions that wrap content in a `NavigationStack + ScrollView` and apply `presentationSurface` for consistent themed sheet presentations. Also adds `sheetTitle` and `sheetCloseButton` toolbar helpers, with adaptive `Button(role: .close)` on iOS 26+.
- **`Callout.swift`**: removes unused `message` parameter.

## Why

Using `.background()` inside a sheet only paints the content area — the sheet's own chrome (the drag indicator area, rounded corners) stays with the system default. `.presentationBackground()` is the correct API for theming the full sheet, but it needed to be paired with surface/level environment propagation to keep child components aware of their context.

## Availability

`presentationBackground` requires iOS 16.4, so `presentationSurface` is gated accordingly. The `greenSheet` helpers fall back to `.surface()` on iOS 16.0–16.3.