### PR TITLE
Add NavigationCloseButton and refactor sheet close

### DIFF
--- a/Sources/SebGreenComponents/Helpers/NavigationCloseButton.swift
+++ b/Sources/SebGreenComponents/Helpers/NavigationCloseButton.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// A button that dismisses or closes the current view, placed in a navigation toolbar.
+///
+/// `NavigationCloseButton` must be used inside a `NavigationStack` to be visible,
+/// since it renders as a toolbar item.
+///
+/// On iOS 26 and later, the system-native close button role is used. On earlier
+/// versions, an `xmark.circle.fill` symbol is shown instead.
+///
+/// Prefer the ``navigationCloseButton(placement:action:)`` modifier for convenient placement.
+///
+/// ```swift
+/// NavigationStack {
+///     MyView()
+///         .toolbar {
+///             ToolbarItem(placement: .topBarTrailing) {
+///                 NavigationCloseButton { dismiss() }
+///             }
+///         }
+/// }
+/// ```
+public struct NavigationCloseButton: View {
+    private let action: () -> Void
+
+    public init(_ action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    public var body: some View {
+        if #available(iOS 26, *) {
+            Button(role: .close, action: action)
+                .tint(.gds(.contentNeutral02))
+        } else {
+            Button(systemName: "xmark.circle.fill", action: action)
+                .foregroundStyle(.gds(.contentNeutral02), .surfaceAware)
+                .font(.system(size: 24))
+                .accessibilityLabel(
+                    String(localized: "GreeniOS.Accessibility.Close", bundle: .module)
+                )
+        }
+    }
+}
+
+extension View {
+    /// Adds a close button to the view's navigation toolbar.
+    ///
+    /// The view must be inside a `NavigationStack` for the button to be visible.
+    ///
+    /// ```swift
+    /// NavigationStack {
+    ///     MyView()
+    ///         .navigationCloseButton { dismiss() }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - placement: The toolbar placement for the button. Defaults to `.topBarTrailing`.
+    ///   - action: The closure to execute when the button is tapped.
+    public func navigationCloseButton(
+        placement: ToolbarItemPlacement = .topBarTrailing,
+        action: @escaping () -> Void
+    ) -> some View {
+        toolbar {
+            ToolbarItem(placement: placement) {
+                NavigationCloseButton(action)
+            }
+        }
+    }
+}
+
+@available(iOS 16)
+#Preview {
+    NavigationStack {
+        Text("Hello World")
+            .navigationCloseButton {}
+            .navigationTitle("Title")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .surface(.neutral01)
+    }
+}

--- a/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
+++ b/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
@@ -14,21 +14,6 @@ private struct GreenSheetNavigationStack<Content: View>: View {
     }
 }
 
-private struct SheetCloseButton: View {
-    let action: () -> Void
-
-    var body: some View {
-        if #available(iOS 26, *) {
-            Button(role: .close, action: action)
-                .tint(.gds(.contentNeutral02))
-        } else {
-            Button(systemName: "xmark.circle.fill", action: action)
-                .foregroundStyle(.gds(.contentNeutral02), .surfaceAware)
-                .font(.system(size: 24))
-        }
-    }
-}
-
 extension View {
     public func greenSheet(
         isPresented: Binding<Bool>,
@@ -98,17 +83,6 @@ extension View {
         }
     }
 
-    public func sheetCloseButton(
-        placement: ToolbarItemPlacement = .topBarTrailing,
-        action: @escaping () -> Void
-    ) -> some View {
-        toolbar {
-            ToolbarItem(placement: placement) {
-                SheetCloseButton(action: action)
-            }
-        }
-    }
-
     @ViewBuilder
     fileprivate func scrollBasedOnSizeIfAvailable() -> some View {
         if #available(iOS 16.4, *) {
@@ -145,7 +119,7 @@ extension View {
         )
         .padding(.horizontal)
         .sheetTitle("Amazing title", typography: .headingS)
-        .sheetCloseButton {
+        .navigationCloseButton {
             present = false
         }
         .presentationDetents([.medium, .large])

--- a/Sources/SebGreenComponents/Resources/Localizable.xcstrings
+++ b/Sources/SebGreenComponents/Resources/Localizable.xcstrings
@@ -37,6 +37,24 @@
         }
       }
     },
+    "GreeniOS.Accessibility.Close" : {
+      "comment" : "VoiceOver label for the navigation close button",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stäng"
+          }
+        }
+      }
+    },
     "GreeniOS.Accessibility.CustomContent.InputFieldError" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/SebGreenComponents/Surface/View+Surface.swift
+++ b/Sources/SebGreenComponents/Surface/View+Surface.swift
@@ -29,11 +29,7 @@ extension View {
         level: Level = .level2
     ) -> some View {
         self
-            .presentationBackground(
-                .levelBased { @Sendable level, _ in
-                    surface.color(for: level)
-                }
-            )
+            .presentationBackground(surface.color(for: level))
             .environment(\.surface, surface)
             .level(level)
     }


### PR DESCRIPTION
Introduce NavigationCloseButton (new helper view) that renders a platform-appropriate close control and a navigationCloseButton View modifier for easy toolbar placement. Remove the duplicated SheetCloseButton and sheetCloseButton modifier from View+GreenSheet and update usages to use navigationCloseButton instead. Add the "GreeniOS.Accessibility.Close" localization entry for VoiceOver. Also simplify presentationBackground usage in View+Surface to call surface.color(for:) directly (minor cleanup).