### PR TITLE
Require iOS 16 and strip availability annotations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "SebGreenComponents",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v16)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/SebGreenComponents/Buttons/GreenButtonStyle+Demo.swift
+++ b/Sources/SebGreenComponents/Buttons/GreenButtonStyle+Demo.swift
@@ -1,7 +1,6 @@
 import GdsKit
 import SwiftUI
 
-@available(iOS 16, *)
 public struct SEBGreenButtonStyleDemo: View {
     @State private var iconPosition: IconPosition = .leading
     @State private var shouldShowIcon = true
@@ -264,8 +263,6 @@ public struct SEBGreenButtonStyleDemo: View {
     }
 }
 
-
-@available(iOS 16, *)
 #Preview {
     NavigationStack {
         SEBGreenButtonStyleDemo()

--- a/Sources/SebGreenComponents/Callout/Callout+Demo.swift
+++ b/Sources/SebGreenComponents/Callout/Callout+Demo.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 16, *)
 public struct CalloutDemo: View {
     @State private var showActionButton = true
     @State private var showCloseButton = true
@@ -115,7 +114,6 @@ public struct CalloutDemo: View {
     }
 }
 
-@available(iOS 16, *)
 #Preview {
     NavigationStack {
         CalloutDemo()

--- a/Sources/SebGreenComponents/DemoContainer.swift
+++ b/Sources/SebGreenComponents/DemoContainer.swift
@@ -1,7 +1,6 @@
 import GdsKit
 import SwiftUI
 
-@available(iOS 16, *)
 struct DemoSection<Content: View>: View {
     private let title: String
     private let content: Content
@@ -28,7 +27,6 @@ struct DemoSection<Content: View>: View {
     }
 }
 
-@available(iOS 16, *)
 struct DemoContainer<Configuration: View, Content: View>: View {
     private let title: String
     private let contentPadding: CGFloat
@@ -97,7 +95,6 @@ struct DemoContainer<Configuration: View, Content: View>: View {
     }
 }
 
-@available(iOS 16, *)
 extension DemoContainer where Configuration == EmptyView {
     init(
         _ title: String,

--- a/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
+++ b/Sources/SebGreenComponents/Helpers/View+GreenSheet.swift
@@ -1,7 +1,6 @@
 import GdsKit
 import SwiftUI
 
-@available(iOS 16, *)
 private struct GreenSheetNavigationStack<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
@@ -30,7 +29,6 @@ private struct SheetCloseButton: View {
     }
 }
 
-@available(iOS 16, *)
 extension View {
     public func greenSheet(
         isPresented: Binding<Bool>,

--- a/Sources/SebGreenComponents/Input/InputField+Demo.swift
+++ b/Sources/SebGreenComponents/Input/InputField+Demo.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 16.0, *)
 public struct InputFieldDemo: View {
     @State private var isOptional = false
     @State private var supportTextEnabled = false
@@ -203,7 +202,6 @@ public struct InputFieldDemo: View {
     }
 }
 
-@available(iOS 16.0, *)
 #Preview {
     NavigationStack {
         InputFieldDemo()

--- a/Sources/SebGreenComponents/Input/InputField.swift
+++ b/Sources/SebGreenComponents/Input/InputField.swift
@@ -198,7 +198,6 @@ extension AccessibilityCustomContentKey {
     )
 }
 
-@available(iOS 16.0, *)
 #Preview {
     InputFieldDemo()
 }

--- a/Sources/SebGreenComponents/Input/Validations/Rules/MaxCharacterRule.swift
+++ b/Sources/SebGreenComponents/Input/Validations/Rules/MaxCharacterRule.swift
@@ -3,7 +3,6 @@ import Accessibility
 // TODO: Remove import UIKit when minimum deployment target is iOS 17+
 import UIKit
 
-@available(iOS 16, *)
 public struct MaxCharacterRule: ValidationRule {
     let maxCharacters: Int
     private let enforcement: Enforcement
@@ -69,7 +68,6 @@ public struct MaxCharacterRule: ValidationRule {
     }
 }
 
-@available(iOS 16, *)
 public extension ValidationRule where Self == MaxCharacterRule {
     static func maxCharacters(
         _ count: Int,

--- a/Sources/SebGreenComponents/Input/Validations/ValidationRuleModifier.swift
+++ b/Sources/SebGreenComponents/Input/Validations/ValidationRuleModifier.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 16.0, *)
 private struct ValidationRuleModifier<Value: Equatable>: ViewModifier {
     private let rules: [any ValidationRule<Value>]
     private let isEnabled: Bool
@@ -84,7 +83,6 @@ private struct ValidationRuleModifier<Value: Equatable>: ViewModifier {
 }
 
 extension View {
-    @available(iOS 16, *)
     @ViewBuilder
     public func applyRules<V: Equatable>(
         to value: Binding<V>,

--- a/Sources/SebGreenComponents/Showcase/Showcase.swift
+++ b/Sources/SebGreenComponents/Showcase/Showcase.swift
@@ -9,7 +9,6 @@ private enum Component: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    @available(iOS 16, *)
     @ViewBuilder
     var view: some View {
         switch self {
@@ -21,7 +20,6 @@ private enum Component: String, CaseIterable, Identifiable {
     }
 }
 
-@available(iOS 16, *)
 public struct Showcase: View {
     private let components = Component.allCases
 
@@ -43,7 +41,6 @@ public struct Showcase: View {
     }
 }
 
-@available(iOS 16, *)
 #Preview {
     NavigationStack {
         Showcase()

--- a/Sources/SebGreenComponents/Toggles/Toggle+Demo.swift
+++ b/Sources/SebGreenComponents/Toggles/Toggle+Demo.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 16, *)
 struct ToggleDemo: View {
     @State private var toggleOn = true
     @State private var toggleOff = false
@@ -26,7 +25,6 @@ struct ToggleDemo: View {
     }
 }
 
-@available(iOS 16, *)
 #Preview {
     ToggleDemo()
 }

--- a/Tests/SebGreenComponentsSnapshotTests/InputFieldSnapshotTests.swift
+++ b/Tests/SebGreenComponentsSnapshotTests/InputFieldSnapshotTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 @testable import SebGreenComponents
 
-@available(iOS 16, *)
 extension View {
     fileprivate func inputFieldSnapshotTest(
         _ suffix: String? = nil,
@@ -25,7 +24,6 @@ extension View {
     }
 }
 
-@available(iOS 16, *)
 final class InputFieldSnapshotTests: SEBViewImageSnapshotTesting {
 
     func test_inputField() {


### PR DESCRIPTION
Update Package.swift to swift-tools-version 5.9 and set platforms to iOS 16. Remove redundant @available(iOS 16/.0) annotations from demo views, previews, view modifiers, validation rules, helpers, showcase, toggles and tests since the package minimum now guarantees iOS 16. Minor formatting/cleanup changes.