### PR TITLE
Rename .seb style factory to .gds

### DIFF
--- a/Sources/SebGreenComponents/Buttons/GreenButtonStyle+Demo.swift
+++ b/Sources/SebGreenComponents/Buttons/GreenButtonStyle+Demo.swift
@@ -20,7 +20,7 @@ public struct SEBGreenButtonStyleDemo: View {
             VStack(spacing: .gds(.spaceXl)) {
                 // Primary with no icon
                 Button("Primary") { }
-                .buttonStyle(.seb(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                .buttonStyle(.gds(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
                 
                 Divider()
                 
@@ -32,7 +32,7 @@ public struct SEBGreenButtonStyleDemo: View {
                             Text("Leading")
                         }
                     }
-                    .buttonStyle(.seb(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                    .buttonStyle(.gds(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
                     
                     Button { } label: {
                         if shouldShowIcon {
@@ -41,7 +41,7 @@ public struct SEBGreenButtonStyleDemo: View {
                             Text("Trailing")
                         }
                     }
-                    .buttonStyle(.seb(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior).iconPosition(.trailing)))
+                    .buttonStyle(.gds(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior).iconPosition(.trailing)))
                 }
                 
                 Divider()
@@ -54,7 +54,7 @@ public struct SEBGreenButtonStyleDemo: View {
                         Text("Secondary")
                     }
                 }
-                .buttonStyle(.seb(.secondary.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                .buttonStyle(.gds(.secondary.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
 
                 Divider()
                 
@@ -66,7 +66,7 @@ public struct SEBGreenButtonStyleDemo: View {
                             Text("Secondary on White")
                         }
                     }
-                    .buttonStyle(.seb(.secondary.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                    .buttonStyle(.gds(.secondary.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
                     .padding()
                 }
                 .surface(.neutral01)
@@ -82,7 +82,7 @@ public struct SEBGreenButtonStyleDemo: View {
                         Text("Tertiary")
                     }
                 }
-                .buttonStyle(.seb(.tertiary.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                .buttonStyle(.gds(.tertiary.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
                 
                 Divider()
                 
@@ -94,7 +94,7 @@ public struct SEBGreenButtonStyleDemo: View {
                         Text("Outline")
                     }
                 }
-                .buttonStyle(.seb(.outline.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                .buttonStyle(.gds(.outline.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
 
                 Divider()
                 
@@ -108,7 +108,7 @@ public struct SEBGreenButtonStyleDemo: View {
                         }
                     }
                 }
-                .buttonStyle(.seb(.negative.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                .buttonStyle(.gds(.negative.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
                 
                 Divider()
                 
@@ -122,7 +122,7 @@ public struct SEBGreenButtonStyleDemo: View {
                         }
                     }
                 }
-                .buttonStyle(.seb(.notice.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                .buttonStyle(.gds(.notice.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
 
                 Divider()
 
@@ -136,7 +136,7 @@ public struct SEBGreenButtonStyleDemo: View {
                         }
                     }
                 }
-                .buttonStyle(.seb(.tonal.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                .buttonStyle(.gds(.tonal.iconPosition(iconPosition).dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
 
                 Divider()
             }
@@ -163,7 +163,7 @@ public struct SEBGreenButtonStyleDemo: View {
                                 Button { } label: {
                                     Icon(systemName: "ellipsis")
                                 }
-                                .buttonStyle(.seb(.primary(shape: .circle).dimensions(buttonDimensions)))
+                                .buttonStyle(.gds(.primary(shape: .circle).dimensions(buttonDimensions)))
                                 .accessibilityLabel("Information")
                                 
                                 Divider()
@@ -180,7 +180,7 @@ public struct SEBGreenButtonStyleDemo: View {
                                         }
                                     }
                                 }
-                                .buttonStyle(.seb(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
+                                .buttonStyle(.gds(.primary.dimensions(buttonDimensions).layoutBehavior(buttonLayoutBehavior)))
                                 
                                 Spacer()
                             }

--- a/Sources/SebGreenComponents/Buttons/GreenButtonStyle.swift
+++ b/Sources/SebGreenComponents/Buttons/GreenButtonStyle.swift
@@ -54,7 +54,7 @@ public struct GreenButtonStyle: ButtonStyle {
         )
         
         configuration.label
-            .labelStyle(.seb(buttonLabelStyle))
+            .labelStyle(.gds(buttonLabelStyle))
             .font(dimensions.font)
             .padding(.vertical, dimensions.verticalPadding)
             .padding(.horizontal, shape.isPill ? dimensions.horizontalPadding : nil)
@@ -109,7 +109,7 @@ extension GreenButtonStyle {
 }
 
 public extension ButtonStyle where Self == GreenButtonStyle {
-    static func seb(_ style: GreenButtonStyle) -> some ButtonStyle  {
+    static func gds(_ style: GreenButtonStyle) -> some ButtonStyle  {
         style
     }
 }

--- a/Sources/SebGreenComponents/Buttons/GreenLabelStyle.swift
+++ b/Sources/SebGreenComponents/Buttons/GreenLabelStyle.swift
@@ -41,7 +41,7 @@ extension LabelStyle where Self == GreenLabelStyle {
         )
     }
     
-    static func seb(_ style: GreenLabelStyle) -> some LabelStyle  {
+    static func gds(_ style: GreenLabelStyle) -> some LabelStyle  {
         style
     }
 }

--- a/Sources/SebGreenComponents/Callout/Callout.swift
+++ b/Sources/SebGreenComponents/Callout/Callout.swift
@@ -46,7 +46,7 @@ public struct Callout: View {
                         systemImage: action.linkStyle?.symbolName ?? "",
                         action: action.perform
                     )
-                    .buttonStyle(.seb(primaryActionStyle))
+                    .buttonStyle(.gds(primaryActionStyle))
                     .level(.level2)
                 }
             }

--- a/Sources/SebGreenComponents/InfoCard.swift
+++ b/Sources/SebGreenComponents/InfoCard.swift
@@ -181,7 +181,7 @@ public struct InfoCardView: View {
         action: @escaping (() -> Void)
     ) -> some View {
         Button(title, action: action)
-            .buttonStyle(.seb(.secondary.dimensions(.small)))
+            .buttonStyle(.gds(.secondary.dimensions(.small)))
     }
 }
 

--- a/Tests/SebGreenComponentsSnapshotTests/GreenButtonStyleSnapshotTests.swift
+++ b/Tests/SebGreenComponentsSnapshotTests/GreenButtonStyleSnapshotTests.swift
@@ -40,7 +40,7 @@ final class GreenButtonStyleSnapshotTests: SEBViewImageSnapshotTesting {
                 }
             }
         }
-        .buttonStyle(.seb(style))
+        .buttonStyle(.gds(style))
         .disabled(isDisabled)
         .padding()
         .frame(width: 320)


### PR DESCRIPTION
Replace the .seb style factory with .gds across the codebase. Updated ButtonStyle and LabelStyle extensions (GreenButtonStyle, GreenLabelStyle) to expose static gds(...) and changed all usages in the demo, callout, info card and snapshot tests to use .gds. This standardizes the style API; consumers must replace .seb(...) calls with .gds(...).