### PR TITLE
chore: bump green-tokens-ios to 0.0.12

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "24edbb18be272119457e14f6ec3e3e1bacbe769a352a68b085c0366ee00c27af",
   "pins" : [
     {
       "identity" : "green-tokens-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/seb-oss/green-tokens-ios",
       "state" : {
-        "revision" : "27d08a902eb26e2ddc89ed34e7dbaf28964e2af4",
-        "version" : "0.0.10"
+        "revision" : "fcb4386b2ad54c6e59a9eac0bbc747529eb07a4f",
+        "version" : "0.0.12"
       }
     },
     {
@@ -47,5 +46,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/seb-oss/green-tokens-ios",
-            exact: "0.0.11"
+            exact: "0.0.12"
         ),
         .package(
             url: "https://github.com/pointfreeco/swift-snapshot-testing",


### PR DESCRIPTION
## Summary

- Updates `green-tokens-ios` dependency from `0.0.11` to `0.0.12`
- Updates `Package.resolved` with the new revision and version pin

## Changes

| File | Change |
|------|--------|
| `Package.swift` | Version pin updated from `0.0.11` → `0.0.12` |
| `Package.resolved` | Revision and version updated to match new release |

## Reviewers

No logic changes — dependency bump only.