### PR TITLE
chore: bump green-tokens-ios to 0.0.13 and set toggle font

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/seb-oss/green-tokens-ios",
-            exact: "0.0.12"
+            exact: "0.0.13"
         ),
         .package(
             url: "https://github.com/pointfreeco/swift-snapshot-testing",

--- a/Sources/SebGreenComponents/Toggles/GdsToggleStyle.swift
+++ b/Sources/SebGreenComponents/Toggles/GdsToggleStyle.swift
@@ -8,6 +8,7 @@ public struct GdsToggleStyle: ToggleStyle {
     public func makeBody(configuration: Configuration) -> some View {
         Toggle(configuration)
             .tint(.gds(.l3Positive01))
+            .font(.gds(.detailMBook))
     }
 }
 


### PR DESCRIPTION
## Summary

- Bumps `green-tokens-ios` from `0.0.12` → `0.0.13`
- Applies `.font(.gds(.detailMBook))` to `GdsToggleStyle` so the toggle label uses the correct GDS typography token