### PR TITLE
fix: resolve iOS 16 crashes in style factories and NavigationCloseButton

### DIFF
--- a/Sources/SebGreenComponents/Buttons/GreenButtonStyle.swift
+++ b/Sources/SebGreenComponents/Buttons/GreenButtonStyle.swift
@@ -109,7 +109,7 @@ extension GreenButtonStyle {
 }
 
 public extension ButtonStyle where Self == GreenButtonStyle {
-    static func gds(_ style: GreenButtonStyle) -> some ButtonStyle  {
+    static func gds(_ style: GreenButtonStyle) -> Self {
         style
     }
 }

--- a/Sources/SebGreenComponents/Buttons/GreenLabelStyle.swift
+++ b/Sources/SebGreenComponents/Buttons/GreenLabelStyle.swift
@@ -41,7 +41,7 @@ extension LabelStyle where Self == GreenLabelStyle {
         )
     }
     
-    static func gds(_ style: GreenLabelStyle) -> some LabelStyle  {
+    static func gds(_ style: GreenLabelStyle) -> Self {
         style
     }
 }

--- a/Sources/SebGreenComponents/Helpers/NavigationCloseButton.swift
+++ b/Sources/SebGreenComponents/Helpers/NavigationCloseButton.swift
@@ -26,6 +26,15 @@ public struct NavigationCloseButton: View {
     public init(_ action: @escaping () -> Void) {
         self.action = action
     }
+    
+    @available(iOS, deprecated: 17, message: "Call `.surfaceAware directly`")
+    private var backgroundStyle: some ShapeStyle {
+        if #available(iOS 17, *) {
+            return .surfaceAware
+        } else {
+            return .clear
+        }
+    }
 
     public var body: some View {
         if #available(iOS 26, *) {
@@ -33,7 +42,10 @@ public struct NavigationCloseButton: View {
                 .tint(.gds(.contentNeutral02))
         } else {
             Button(systemName: "xmark.circle.fill", action: action)
-                .foregroundStyle(.gds(.contentNeutral02), .surfaceAware)
+                .foregroundStyle(
+                    .gds(.contentNeutral02),
+                    backgroundStyle
+                )
                 .font(.system(size: 24))
                 .accessibilityLabel(
                     String(localized: "GreeniOS.Accessibility.Close", bundle: .module)
@@ -76,6 +88,6 @@ extension View {
             .navigationCloseButton {}
             .navigationTitle("Title")
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .surface(.neutral01)
+            .surface(.neutral02)
     }
 }


### PR DESCRIPTION
## Description

Two iOS 16 regressions that caused crashes or incorrect rendering.

### 1. Crash in `GreenButtonStyle` and `GreenLabelStyle` style factories

`gds(_:)` on both `ButtonStyle where Self == GreenButtonStyle` and `LabelStyle where Self == GreenLabelStyle` returned `some ButtonStyle` / `some LabelStyle` (opaque return types). On iOS 16 this caused a runtime crash when the style functions were invoked.

**Fix:** Changed return types to `Self`, which is the correct concrete type for constrained protocol extensions of this form.

### 2. `NavigationCloseButton` ignoring surface on iOS 16

`.surfaceAware` was passed directly as a secondary `foregroundStyle` argument. Since `.surfaceAware` requires iOS 17+, calling it on iOS 16 crashed or produced unexpected rendering, and the button background did not reflect the parent surface color.

**Fix:** Introduced a `backgroundStyle` computed property gated on `#available(iOS 17, *)`, falling back to `.clear` on iOS 16.

## Testing

- Verified on iOS 16 simulator that buttons no longer crash and the close button renders with the correct tint.