### PR TITLE
fix: guard Callout preview with #if DEBUG

### DIFF
--- a/Sources/SebGreenComponents/Callout/Callout+Demo.swift
+++ b/Sources/SebGreenComponents/Callout/Callout+Demo.swift
@@ -139,9 +139,11 @@ public struct CalloutDemo: View {
     }
 }
 
+#if DEBUG
 #Preview {
     NavigationStack {
         CalloutDemo()
             .previewByRegisteringFonts()
     }
 }
+#endif


### PR DESCRIPTION
## What

Wraps the `CalloutDemo` `#Preview` block in `#if DEBUG` / `#endif` so preview code is only compiled in debug builds.

## Why

Preview-only symbols should not be included in release targets. Without the guard, the preview is compiled unconditionally, which can cause build issues in release configurations where Xcode preview infrastructure is unavailable.