### PR TITLE
i18n: update Swedish translation for Dismiss from 'Avfärda' to 'Ta bort'

### DIFF
--- a/Sources/SebGreenComponents/Resources/Localizable.xcstrings
+++ b/Sources/SebGreenComponents/Resources/Localizable.xcstrings
@@ -84,7 +84,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Avfärda"
+            "value" : "Ta bort"
           }
         }
       }


### PR DESCRIPTION
## What changed

Updates the Swedish (`sv`) localization for the "Dismiss" string key from `Avfärda` to `Ta bort`.

## Why

`Ta bort` is a more natural and commonly used Swedish phrasing for a dismiss/remove action in UI contexts.

## Reviewer notes

Single string change in `Localizable.xcstrings` — no code changes.